### PR TITLE
fixed the saving function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ dist/
 __pycache__/
 **/.DS_Store
 venv/
+bin/
+lib/
+lib64
+pyvenv.cfg

--- a/src/resources.py
+++ b/src/resources.py
@@ -313,10 +313,14 @@ class DynamicAsssets:
         # root.withdraw()
         fd = SaveAs(self.tk_start_window.window)
         filename = fd.show()
-        if filename is not None and str(filename).strip() != "":
-            # Ensure the file ends in ".xml"
-            if not str(filename).lower().endswith(".xml"):
-                filename = filename + ".xml"
-            new_file = open(filename, "w")
-            new_file.write(self.current_file_str)
-        return filename
+        if type(filename) == str:
+            if filename is not None and str(filename).strip() != "":
+                # Ensure the file ends in ".xml"
+                if not str(filename).lower().endswith(".xml"):
+                    filename = filename + ".xml" 
+                new_file = open(filename, "w")
+                new_file.write(self.current_file_str)
+            return filename
+        else:
+            print('Canceled Saving!')
+            return None

--- a/src/resources.py
+++ b/src/resources.py
@@ -322,5 +322,5 @@ class DynamicAsssets:
                 new_file.write(self.current_file_str)
             return filename
         else:
-            print('Canceled Saving!')
+            print('Cancelled Saving!')
             return None


### PR DESCRIPTION
In the saving function my_save_file_proc(), if the user cancelled saving of the world the program would freeze as the Tkinter library function SaveAs( ) returns a tuple instead of a string and there was no condition to check this. I have added an if statement to check if the filename is a string type. If it is, it will save it, if it is not, it will print out cancelled saving.